### PR TITLE
feat: add image generation provider support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,17 @@ outputs/
 | `doraemon` | Colorful, friendly style with illustrations |
 | `custom` | Any text description for LLM-generated style |
 
+### Image Generation Providers
+
+- Set `IMAGE_GEN_PROVIDER` in `paper2slides/.env` to choose the backend:
+  - `openrouter` (default): uses `IMAGE_GEN_API_KEY`, `IMAGE_GEN_BASE_URL`, and `IMAGE_GEN_MODEL` (default `google/gemini-3-pro-image-preview`)
+  - `google`: uses the official Gemini API at `GOOGLE_GENAI_BASE_URL` (default `https://generativelanguage.googleapis.com/v1beta`), `IMAGE_GEN_API_KEY`, `IMAGE_GEN_MODEL` (default `models/gemini-3-pro-image-preview`, must be image-capable), and `IMAGE_GEN_RESPONSE_MIME_TYPE` (default `text/plain`; use text types if your model does not support image responses)
+- Reference figures are sent as inline data when supported (Google) or as `image_url` attachments (OpenRouter).
+
 ### Image Generation Notes
 
 > [!TIP]
-> Paper2Slides uses `gemini-3-pro-image-preview` (Nano Banana Pro Preview) for image generation. Key findings:
+> By default Paper2Slides uses `gemini-3-pro-image-preview` (OpenRouter) for image generation; you can switch to an image-capable Google Gemini model (e.g., `models/gemini-1.5-flash`) via `IMAGE_GEN_PROVIDER=google`. Key findings:
 > 
 > - **Mood Keywords**: Words like "warm", "elegant", "vibrant" strongly influence the overall color palette
 > - **Layout vs Style**: Fine-grained *layout* instructions ground well; fine-grained *element styling* does not

--- a/paper2slides/.env.example
+++ b/paper2slides/.env.example
@@ -2,6 +2,11 @@
 RAG_LLM_API_KEY=""
 RAG_LLM_BASE_URL=""
 
-# OpenRouter
+# Image Generation
+# provider: openrouter (default) or google
+IMAGE_GEN_PROVIDER="openrouter"
 IMAGE_GEN_API_KEY=""
 IMAGE_GEN_BASE_URL=""
+IMAGE_GEN_MODEL=""
+IMAGE_GEN_RESPONSE_MIME_TYPE="image/png"
+GOOGLE_GENAI_BASE_URL=""


### PR DESCRIPTION
This pull request adds support for choosing between OpenRouter and the official Google Gemini API as image generation backends in Paper2Slides. It introduces a new configuration option (`IMAGE_GEN_PROVIDER`) and updates both the documentation and code to enable seamless switching, including support for Google Gemini’s image-capable models and relevant environment variables.

**Image Generation Provider Support:**

* Added a new `IMAGE_GEN_PROVIDER` environment variable and related options (`IMAGE_GEN_MODEL`, `IMAGE_GEN_RESPONSE_MIME_TYPE`, `GOOGLE_GENAI_BASE_URL`) to `.env.example` for configuring the image generation backend.
* Updated the `README.md` with detailed instructions on how to select and configure the image generation provider, including notes on model defaults and reference image handling.

**Codebase Enhancements for Provider Switching:**

* Refactored `image_generator.py` to support both OpenRouter and Google Gemini APIs, including new initialization parameters and logic for selecting the provider and model defaults.
* Implemented a new `_call_model_google` method for calling the official Google Gemini API, handling prompt composition, inline reference images, error handling, and response parsing for image generation.
* Updated the internal model-calling logic to dispatch requests to either the OpenRouter or Google handler based on configuration.

**Other Minor Improvements:**

* Added the missing `requests` import required for Google API calls.