### PR TITLE
fix(api): accept supported document input formats

### DIFF
--- a/api/file_utils.py
+++ b/api/file_utils.py
@@ -1,0 +1,38 @@
+"""Helpers for identifying files accepted by the API input pipeline."""
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from paper2slides.file_formats import SUPPORTED_FILE_EXTENSIONS
+
+# Keep the API's input contract aligned with the formats used by BatchParser.
+SUPPORTED_INPUT_EXTENSIONS = SUPPORTED_FILE_EXTENSIONS
+
+
+def is_supported_input_file(filename: str) -> bool:
+    """Return whether ``filename`` has a format handled by BatchParser."""
+    return Path(filename).suffix.lower() in SUPPORTED_INPUT_EXTENSIONS
+
+
+def filter_supported_files(
+    files: Iterable[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    """Keep uploaded file records that can be passed to the input pipeline."""
+    return [
+        file_record
+        for file_record in files
+        if is_supported_input_file(str(file_record.get("filename", "")))
+    ]
+
+
+def find_supported_session_files(session_dir: Path) -> list[Path]:
+    """Return supported uploaded files from a session in stable name order."""
+    return sorted(
+        (
+            file_path
+            for file_path in session_dir.iterdir()
+            if file_path.is_file() and is_supported_input_file(file_path.name)
+        ),
+        key=lambda file_path: file_path.name.lower(),
+    )

--- a/api/server.py
+++ b/api/server.py
@@ -29,6 +29,7 @@ from paper2slides.core import (
 )
 from paper2slides.utils.path_utils import get_project_name
 from paper2slides.utils import setup_logging
+from api.file_utils import filter_supported_files, find_supported_session_files
 
 # Configuration - use project root directories
 UPLOAD_DIR = PROJECT_ROOT / "sources" / "uploads"
@@ -320,10 +321,10 @@ async def generate_slides_with_pipeline(
     Returns:
         Dictionary with slides info and output paths
     """
-    # Find PDF files (support multiple PDFs in one session)
-    pdf_files = [f for f in files if f['filename'].lower().endswith('.pdf')]
-    if not pdf_files:
-        raise ValueError("No PDF file found in uploaded files")
+    # Keep the API input contract aligned with the formats supported by BatchParser.
+    input_files = filter_supported_files(files)
+    if not input_files:
+        raise ValueError("No supported input file found in uploaded files")
     
     # Parse style and message
     # Priority: message > style parameter
@@ -342,26 +343,26 @@ async def generate_slides_with_pipeline(
         style_type = "custom"
         custom_style = style
     
-    # Handle multiple PDFs: all paths in a list
-    pdf_paths = [f['path'] for f in pdf_files]
+    # Handle multiple supported input files as one project.
+    input_paths = [f['path'] for f in input_files]
     
-    # Determine paths (using session-based directory for multiple PDFs)
-    if len(pdf_paths) > 1:
-        # Multiple PDFs: use session_id as the identifier
+    # Determine paths (using session-based directory for multiple inputs)
+    if len(input_paths) > 1:
+        # Multiple input files: use session_id as the identifier
         project_name = f"session_{session_id[:8]}"
         # Use session directory as input_path for multiple files
-        input_path = str(Path(pdf_paths[0]).parent)
-        print(f"Processing {len(pdf_paths)} PDFs as a single project")
+        input_path = str(Path(input_paths[0]).parent)
+        print(f"Processing {len(input_paths)} input files as a single project")
     else:
-        # Single PDF: use pdf name
-        project_name = get_project_name(pdf_paths[0])
-        # Use the single PDF path as input_path
-        input_path = pdf_paths[0]
+        # Single input file: use its name for the project.
+        project_name = get_project_name(input_paths[0])
+        input_path = input_paths[0]
     
     # Build config matching main.py format
     config = {
         "input_path": input_path,  # Required by RAG stage
-        "pdf_paths": pdf_paths,  # Support multiple PDFs
+        # Keep the legacy key so existing PDF-only state/config hashes stay stable.
+        "pdf_paths": input_paths,
         "content_type": content,
         "output_type": output_type,
         "style": style_type,
@@ -376,8 +377,8 @@ async def generate_slides_with_pipeline(
     
     print(f"\nPipeline Configuration:")
     print(f"  Project: {project_name}")
-    print(f"  PDFs: {len(pdf_paths)}")
-    for i, path in enumerate(pdf_paths, 1):
+    print(f"  Input files: {len(input_paths)}")
+    for i, path in enumerate(input_paths, 1):
         print(f"    [{i}] {Path(path).name}")
     if message and message.strip():
         print(f"  Message: {message}")
@@ -445,16 +446,15 @@ def _update_state_on_error(
     from paper2slides.core.state import load_state, save_state
     import json
     
-    # Find PDF files
-    pdf_files = [f for f in files if f['filename'].lower().endswith('.pdf')]
-    if not pdf_files:
+    input_files = filter_supported_files(files)
+    if not input_files:
         return
     
-    pdf_paths = [f['path'] for f in pdf_files]
-    if len(pdf_paths) > 1:
+    input_paths = [f['path'] for f in input_files]
+    if len(input_paths) > 1:
         project_name = f"session_{session_id[:8]}"
     else:
-        project_name = get_project_name(pdf_paths[0])
+        project_name = get_project_name(input_paths[0])
     
     # Determine which stage failed by checking state file
     base_dir = get_base_dir(str(OUTPUT_DIR), project_name, content)
@@ -556,16 +556,16 @@ async def get_status(session_id: str):
         if not session_dir.exists():
             raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
         
-        # Get PDF files from session
-        pdf_files = list(session_dir.glob("*.pdf"))
-        if not pdf_files:
+        # Get supported input files from the session.
+        input_files = find_supported_session_files(session_dir)
+        if not input_files:
             return {"session_id": session_id, "status": "no_files", "stages": {}}
         
         # Determine project name and paths
-        if len(pdf_files) > 1:
+        if len(input_files) > 1:
             project_name = f"session_{session_id[:8]}"
         else:
-            project_name = get_project_name(str(pdf_files[0]))
+            project_name = get_project_name(str(input_files[0]))
         
         # Try to find the state file matching session_id
         from paper2slides.core.paths import get_base_dir
@@ -664,11 +664,19 @@ async def get_result(session_id: str):
             
             # Get output_type from state
             session_dir = UPLOAD_DIR / session_id
-            pdf_files = list(session_dir.glob("*.pdf"))
-            if len(pdf_files) > 1:
+            input_files = find_supported_session_files(session_dir)
+            if not input_files:
+                return JSONResponse(
+                    status_code=404,
+                    content={
+                        "message": "No supported input files found for session",
+                        "session_id": session_id,
+                    },
+                )
+            if len(input_files) > 1:
                 project_name = f"session_{session_id[:8]}"
             else:
-                project_name = get_project_name(str(pdf_files[0]))
+                project_name = get_project_name(str(input_files[0]))
             
             # Try to get output type from state
             from paper2slides.core.paths import get_base_dir
@@ -770,4 +778,3 @@ if __name__ == "__main__":
         limit_concurrency=10,    
         limit_max_requests=1000  
     )
-

--- a/api/tests/test_file_utils.py
+++ b/api/tests/test_file_utils.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from api.file_utils import (
+    SUPPORTED_INPUT_EXTENSIONS,
+    filter_supported_files,
+    find_supported_session_files,
+    is_supported_input_file,
+)
+
+
+def test_supported_extensions_include_batch_parser_document_formats():
+    assert {".pdf", ".md", ".doc", ".docx", ".ppt", ".pptx"}.issubset(
+        SUPPORTED_INPUT_EXTENSIONS
+    )
+    assert ".markdown" not in SUPPORTED_INPUT_EXTENSIONS
+
+
+def test_filter_supported_files_is_case_insensitive():
+    files = [
+        {"filename": "notes.MD", "path": "/tmp/notes.MD"},
+        {"filename": "report.DOCX", "path": "/tmp/report.DOCX"},
+        {"filename": "notes.markdown", "path": "/tmp/notes.markdown"},
+        {"filename": "archive.zip", "path": "/tmp/archive.zip"},
+    ]
+
+    filtered = filter_supported_files(files)
+
+    assert [file_record["filename"] for file_record in filtered] == [
+        "notes.MD",
+        "report.DOCX",
+    ]
+    assert is_supported_input_file("presentation.PPTX")
+
+
+def test_find_supported_session_files_includes_text_and_office_inputs(tmp_path: Path):
+    for filename in ["z-notes.md", "a-report.docx", "ignored.zip"]:
+        (tmp_path / filename).touch()
+
+    assert [path.name for path in find_supported_session_files(tmp_path)] == [
+        "a-report.docx",
+        "z-notes.md",
+    ]

--- a/paper2slides/file_formats.py
+++ b/paper2slides/file_formats.py
@@ -1,0 +1,11 @@
+"""File formats accepted by the document parsing pipeline."""
+
+OFFICE_FORMATS = frozenset({".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"})
+IMAGE_FORMATS = frozenset(
+    {".png", ".jpeg", ".jpg", ".bmp", ".tiff", ".tif", ".gif", ".webp"}
+)
+TEXT_FORMATS = frozenset({".txt", ".md"})
+
+SUPPORTED_FILE_EXTENSIONS = frozenset(
+    {".pdf"} | OFFICE_FORMATS | IMAGE_FORMATS | TEXT_FORMATS
+)

--- a/paper2slides/raganything/parser.py
+++ b/paper2slides/raganything/parser.py
@@ -29,6 +29,12 @@ from typing import (
     TypeVar,
 )
 
+from paper2slides.file_formats import (
+    IMAGE_FORMATS as SHARED_IMAGE_FORMATS,
+    OFFICE_FORMATS as SHARED_OFFICE_FORMATS,
+    TEXT_FORMATS as SHARED_TEXT_FORMATS,
+)
+
 T = TypeVar("T")
 
 
@@ -51,9 +57,9 @@ class Parser:
     """
 
     # Define common file formats
-    OFFICE_FORMATS = {".doc", ".docx", ".ppt", ".pptx", ".xls", ".xlsx"}
-    IMAGE_FORMATS = {".png", ".jpeg", ".jpg", ".bmp", ".tiff", ".tif", ".gif", ".webp"}
-    TEXT_FORMATS = {".txt", ".md"}
+    OFFICE_FORMATS = SHARED_OFFICE_FORMATS
+    IMAGE_FORMATS = SHARED_IMAGE_FORMATS
+    TEXT_FORMATS = SHARED_TEXT_FORMATS
 
     # Class-level logger
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

- align API input discovery with the formats already handled by `BatchParser`
- support Markdown, Office, text, image, and PDF inputs across generation, status, error-state, and result lookup
- keep the legacy `pdf_paths` config key so existing PDF state/config hashes remain stable
- centralize supported extensions and add dependency-free regression tests

## Root cause

The frontend and parser accepted non-PDF documents, but API generation and session lookup filtered every upload through hard-coded `*.pdf` checks.

## Validation

- `python3 -m pytest api/tests/test_file_utils.py -q` — 3 passed
- `ruff check api/file_utils.py api/tests/test_file_utils.py paper2slides/file_formats.py`
- `ruff format --check api/file_utils.py api/tests/test_file_utils.py paper2slides/file_formats.py`
- `python3 -m compileall -q api/server.py api/file_utils.py api/tests/test_file_utils.py paper2slides/file_formats.py paper2slides/raganything/parser.py`
- `git diff --check`

Full document conversion still depends on the parser backend and its external tools (for example Docling or LibreOffice for Office files).

Fixes #30

