### PR TITLE
feat(image-gen): add Atlas Cloud as a third image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,10 @@ outputs/
 - Set `IMAGE_GEN_PROVIDER` in `paper2slides/.env` to choose the backend:
   - `openrouter` (default): uses `IMAGE_GEN_API_KEY`, `IMAGE_GEN_BASE_URL`, and `IMAGE_GEN_MODEL` (default `google/gemini-3-pro-image-preview`)
   - `google`: uses the official Gemini API at `GOOGLE_GENAI_BASE_URL` (default `https://generativelanguage.googleapis.com/v1beta`), `IMAGE_GEN_API_KEY`, `IMAGE_GEN_MODEL` (default `models/gemini-3-pro-image-preview`, must be image-capable), and `IMAGE_GEN_RESPONSE_MIME_TYPE` (default `text/plain`; use text types if your model does not support image responses)
-- Reference figures are sent as inline data when supported (Google) or as `image_url` attachments (OpenRouter).
+  - `atlas`: uses [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=paper2slides) with `IMAGE_GEN_API_KEY`, `IMAGE_GEN_BASE_URL` (default `https://api.atlascloud.ai/api/v1/model`) and `IMAGE_GEN_MODEL` (default `google/nano-banana-pro/text-to-image`). Images go through Atlas's async media API (submit, then poll), which is why this is a separate branch rather than an `IMAGE_GEN_BASE_URL` override on the `openrouter` path — verified: its image models are not reachable from `/v1/chat/completions`. Custom styles still work on this provider because the style-processing LLM call uses Atlas's OpenAI-compatible chat endpoint.
+- Reference figures are sent as inline data when supported (Google, Atlas) or as `image_url` attachments (OpenRouter).
+
+**Atlas size controls differ per model family (measured, not copied from docs):** `nano-banana` models ignore `size` and honour `aspect_ratio` (`IMAGE_GEN_ASPECT_RATIO`, default `16:9` for slides), while `seedream` models honour an explicit `size` (`IMAGE_GEN_SIZE`) and reject anything under 921600 pixels. A run that passes reference figures switches to the model's `/edit` task automatically. The returned container is not fixed — the same model returned PNG on one call and JPEG on the next — so the mime type comes from the response rather than being assumed.
 
 ### Image Generation Notes
 

--- a/paper2slides/.env.example
+++ b/paper2slides/.env.example
@@ -5,10 +5,21 @@ RAG_LLM_BASE_URL=""
 RAG_LLM_MAX_TOKENS=""
 
 # Image Generation
-# provider: openrouter (default) or google
+# provider: openrouter (default), google, or atlas
 IMAGE_GEN_PROVIDER="openrouter"
 IMAGE_GEN_API_KEY=""
 IMAGE_GEN_BASE_URL=""
 IMAGE_GEN_MODEL=""
 IMAGE_GEN_RESPONSE_MIME_TYPE="image/png"
 GOOGLE_GENAI_BASE_URL=""
+
+# Atlas Cloud (IMAGE_GEN_PROVIDER="atlas")
+# Images go through Atlas's async media API; the base URL below is its default.
+# IMAGE_GEN_API_KEY="<atlascloud-api-key>"
+# IMAGE_GEN_BASE_URL="https://api.atlascloud.ai/api/v1/model"
+# IMAGE_GEN_MODEL="google/nano-banana-pro/text-to-image"
+# nano-banana models honour aspect_ratio (default 16:9 for slides):
+# IMAGE_GEN_ASPECT_RATIO="16:9"
+# seedream models honour an explicit size instead (min 921600 pixels):
+# IMAGE_GEN_MODEL="bytedance/seedream-v4"
+# IMAGE_GEN_SIZE="1280x720"

--- a/paper2slides/generator/image_generator.py
+++ b/paper2slides/generator/image_generator.py
@@ -54,6 +54,22 @@ class ProcessedStyle:
     error: Optional[str] = None
 
 
+def _sniff_mime(content: bytes) -> str:
+    """Name the container after the bytes.
+
+    Verified: the same Atlas model returned PNG on one call and JPEG on the
+    next, so the container cannot be assumed from the model id. The response
+    Content-Type is used first and this is the fallback.
+    """
+    if content[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if content[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if content[:4] == b"RIFF" and content[8:12] == b"WEBP":
+        return "image/webp"
+    return "application/octet-stream"
+
+
 def process_custom_style(client: OpenAI, user_style: str, model: str = None) -> ProcessedStyle:
     """Process user's custom style request with LLM."""
     model = model or os.getenv("LLM_MODEL", "openai/gpt-4o-mini")
@@ -77,6 +93,22 @@ def process_custom_style(client: OpenAI, user_style: str, model: str = None) -> 
         return ProcessedStyle(style_name="", color_tone="", special_elements="", decorations="", valid=False, error=str(e))
 
 
+# Atlas Cloud serves images through an async submit-then-poll media API, and its
+# OpenAI-compatible chat endpoint separately. Verified against the live service:
+# the image models are not reachable from /v1/chat/completions (400), so this
+# provider posts to the media API instead of reusing the OpenAI client.
+ATLAS_DEFAULT_BASE_URL = "https://api.atlascloud.ai/api/v1/model"
+ATLAS_CHAT_BASE_URL = "https://api.atlascloud.ai/v1"
+ATLAS_DEFAULT_MODEL = "google/nano-banana-pro/text-to-image"
+ATLAS_EDIT_SUFFIX = "/edit"
+ATLAS_POLL_INTERVAL = 5
+ATLAS_POLL_TIMEOUT = 600
+# api.atlascloud.ai answers some clients' default User-Agent with 403 (error
+# code 1010), so every request sends an explicit one.
+ATLAS_USER_AGENT = "paper2slides/1"
+ATLAS_ASPECT_RATIO = os.getenv("IMAGE_GEN_ASPECT_RATIO", "16:9")
+
+
 class ImageGenerator:
     """Generate poster/slides images from ContentPlan."""
     
@@ -91,7 +123,8 @@ class ImageGenerator:
     ):
         self.provider = (provider or os.getenv("IMAGE_GEN_PROVIDER", "openrouter")).lower()
         self.api_key = api_key or os.getenv("IMAGE_GEN_API_KEY", "")
-        self.base_url = base_url or os.getenv("IMAGE_GEN_BASE_URL", "https://openrouter.ai/api/v1")
+        default_base_url = ATLAS_DEFAULT_BASE_URL if self.provider == "atlas" else "https://openrouter.ai/api/v1"
+        self.base_url = base_url or os.getenv("IMAGE_GEN_BASE_URL", default_base_url)
         self.google_api_base_url = (google_api_base_url or os.getenv("GOOGLE_GENAI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta")).rstrip("/")
         self.response_mime_type = response_mime_type or os.getenv("IMAGE_GEN_RESPONSE_MIME_TYPE", "text/plain")
         self.model = model or os.getenv("IMAGE_GEN_MODEL")
@@ -100,6 +133,10 @@ class ImageGenerator:
             if self.provider == "google":
                 # Official Gemini API image-capable default
                 self.model = "models/gemini-1.5-flash"
+            elif self.provider == "atlas":
+                # Best text rendering of the Atlas image models, and it honours
+                # aspect_ratio, which matters for 16:9 slides.
+                self.model = ATLAS_DEFAULT_MODEL
             else:
                 self.model = "google/gemini-3-pro-image-preview"
         
@@ -107,6 +144,14 @@ class ImageGenerator:
             self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         elif self.provider == "google":
             self.client = None
+        elif self.provider == "atlas":
+            # Images go through the async media API below, but the OpenAI-compatible
+            # chat endpoint is still used for custom-style processing, so custom
+            # styles keep working on this provider.
+            self.client = OpenAI(
+                api_key=self.api_key,
+                base_url=os.getenv("ATLAS_CHAT_BASE_URL", ATLAS_CHAT_BASE_URL),
+            )
         else:
             raise ValueError(f"Unsupported image generation provider: {self.provider}")
     
@@ -405,6 +450,8 @@ class ImageGenerator:
         """Call image generation provider based on configuration."""
         if self.provider == "google":
             return self._call_model_google(prompt, reference_images)
+        if self.provider == "atlas":
+            return self._call_model_atlas(prompt, reference_images)
         return self._call_model_openrouter(prompt, reference_images)
     
     def _call_model_openrouter(self, prompt: str, reference_images: List[dict]) -> tuple:
@@ -478,6 +525,101 @@ class ImageGenerator:
                     continue
                 raise
         
+        raise RuntimeError("Image generation failed after all retry attempts")
+    
+    def _call_model_atlas(self, prompt: str, reference_images: List[dict]) -> tuple:
+        """Call Atlas Cloud's media API: submit a job, poll it, return the bytes.
+
+        Reference images travel in one newline-separated `images` field, and the
+        model id selects the task, so a run with references switches to the
+        model's edit task.
+        """
+        logger = logging.getLogger(__name__)
+        base_url = self.base_url.rstrip("/")
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": ATLAS_USER_AGENT,
+        }
+
+        model = self.model
+        images = [
+            f"data:{img['mime_type']};base64,{img['base64']}"
+            for img in reference_images
+            if img.get("base64") and img.get("mime_type")
+        ]
+        if images and not model.endswith(ATLAS_EDIT_SUFFIX):
+            model = model.rsplit("/", 1)[0] + ATLAS_EDIT_SUFFIX
+
+        payload = {"model": model, "prompt": prompt}
+        # Measured: nano-banana models ignore `size` and honour `aspect_ratio`,
+        # while seedream models honour `size` (and reject anything under
+        # 921600 pixels). Send the one the configured model actually reads.
+        if "nano-banana" in model:
+            payload["aspect_ratio"] = ATLAS_ASPECT_RATIO
+        elif os.getenv("IMAGE_GEN_SIZE"):
+            payload["size"] = os.getenv("IMAGE_GEN_SIZE").replace("x", "*")
+        if images:
+            payload["images"] = "\n".join(images)
+
+        max_retries = 3
+        retry_delay = 2  # seconds
+
+        for attempt in range(max_retries):
+            try:
+                logger.info(f"Calling Atlas image API (attempt {attempt + 1}/{max_retries})...")
+                submitted = requests.post(
+                    f"{base_url}/generateImage", headers=headers, json=payload, timeout=120
+                )
+                if submitted.status_code >= 400:
+                    raise RuntimeError(
+                        f"Atlas submit failed ({submitted.status_code}): {submitted.text[:300]}"
+                    )
+                prediction_id = (submitted.json().get("data") or {}).get("id")
+                if not prediction_id:
+                    raise RuntimeError(f"Atlas returned no prediction id: {submitted.text[:300]}")
+
+                deadline = time.monotonic() + ATLAS_POLL_TIMEOUT
+                while True:
+                    time.sleep(ATLAS_POLL_INTERVAL)
+                    polled = requests.get(
+                        f"{base_url}/prediction/{prediction_id}", headers=headers, timeout=120
+                    )
+                    if polled.status_code >= 400:
+                        raise RuntimeError(
+                            f"Atlas poll failed ({polled.status_code}): {polled.text[:300]}"
+                        )
+                    data = polled.json().get("data") or {}
+                    status = data.get("status")
+                    if status == "completed":
+                        outputs = data.get("outputs") or []
+                        if not outputs:
+                            raise RuntimeError("Atlas completed without an image URL")
+                        # The result URL is short-lived, so download it right away.
+                        downloaded = requests.get(
+                            outputs[0], headers={"User-Agent": ATLAS_USER_AGENT}, timeout=300
+                        )
+                        downloaded.raise_for_status()
+                        content = downloaded.content
+                        mime_type = downloaded.headers.get("Content-Type") or _sniff_mime(content)
+                        logger.info("Image generation successful")
+                        return content, mime_type
+                    if status == "failed":
+                        raise RuntimeError(f"Atlas generation failed: {data.get('error') or data}")
+                    if time.monotonic() > deadline:
+                        raise RuntimeError(
+                            f"Atlas prediction {prediction_id} still {status} after {ATLAS_POLL_TIMEOUT}s"
+                        )
+
+            except Exception as e:
+                logger.error(
+                    f"Error in Atlas API call (attempt {attempt + 1}/{max_retries}): {str(e)}"
+                )
+                if attempt < max_retries - 1:
+                    time.sleep(retry_delay * (attempt + 1))
+                    continue
+                raise
+
         raise RuntimeError("Image generation failed after all retry attempts")
     
     def _call_model_google(self, prompt: str, reference_images: List[dict]) -> tuple:


### PR DESCRIPTION
## Summary

`IMAGE_GEN_PROVIDER` already switches between `openrouter` and `google`. This adds a third value,
`atlas`, which serves the same model families (nano-banana-pro, gpt-image-2, seedream) through
[Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=paper2slides).
Defaults are unchanged: without `IMAGE_GEN_PROVIDER=atlas` nothing behaves differently.

## Why a separate branch instead of just an `IMAGE_GEN_BASE_URL` override

I tried the cheap version first — point the existing `openrouter` path at Atlas and change the model
id. **It does not work, and I verified that against the live service:** Atlas's image models return
`400` from `/v1/chat/completions`, with and without `extra_body={"modalities": ["image","text"]}`.
Images go through an async media API instead (`POST /generateImage`, then poll
`/prediction/{id}`), so `_call_model_atlas()` implements submit → poll → download and returns the
same `(bytes, mime_type)` tuple as the other two branches. Retry count and backoff match the
existing paths.

## Custom styles are not silently degraded

`process_custom_style()` needs a chat client. On the `google` branch `self.client` is `None`, so
`--style custom` cannot work there. For `atlas` the client is still constructed, pointed at Atlas's
**OpenAI-compatible chat endpoint** (that one does work), so custom styles keep functioning on this
provider.

## Measured behaviour, written down rather than left to be rediscovered

| Finding | Detail |
|---|---|
| Size controls differ **per model family** | `nano-banana` models ignore `size` and honour `aspect_ratio` (`IMAGE_GEN_ASPECT_RATIO`, default `16:9` for slides); `seedream` models honour an explicit `size` (`IMAGE_GEN_SIZE`) |
| seedream has a floor | Anything under **921600 pixels** is rejected — `1024x576` came back as `image size must be at least 921600 pixels` |
| Reference figures | Travel in one newline-separated `images` field; the model id selects the task, so a run with references switches to the model's `/edit` task automatically |
| Container is **not** fixed | The *same* model returned PNG on one call and JPEG on the next, so the mime type comes from the response `Content-Type` with a byte-signature fallback instead of being assumed |
| Edge rejects default agents | `api.atlascloud.ai` answers some clients' default `User-Agent` with `403 error code 1010`, so requests send an explicit one |

The payload sends whichever size control the configured model actually reads, so a caller does not
have to remember which family they picked.

## Validation

Run end to end through `ImageGenerator` (not by calling the API directly):

- Text-only slide render → **1376×768 PNG**, 661 KB.
- Same call with a reference figure → switched to `/edit`, returned **1376×768 JPEG**, 554 KB.
- Provider wiring checked: `provider=atlas`, default model `google/nano-banana-pro/text-to-image`,
  media base URL defaulted, chat client constructed.

`.env.example` and the README's "Image Generation Providers" section document the new provider and
the per-family size controls. Keys are placeholders throughout; no credentials in the diff.

<!-- atlas-partnership-start -->
---

### 🤝 Partnership & contact

This PR comes from the **Atlas Cloud** team. Beyond the integration above, we'd love to explore a closer collaboration with **Paper2Slides** — for example **co-marketing** or a featured integration.

If that sounds interesting, reach out anytime:
- 📧 **marketing@atlascloud.ai**
- 🌐 https://www.atlascloud.ai
- 📚 Docs: https://www.atlascloud.ai/docs

And of course, happy to revise this PR to match your project's conventions — just leave a comment. 🙌
<!-- atlas-partnership-end -->
